### PR TITLE
Remove Google public DNS from kitchen yaml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,7 +40,3 @@ suites:
     attributes:
       chef-zero:
         start: true
-      resolver:
-        nameservers:
-          - 8.8.8.8
-          - 8.8.4.4


### PR DESCRIPTION
Having the Google Public DNS nameservers in `.kitchen.yml` can cause problems when users are behind proxies.