### PR TITLE
use latest chef-zero cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,6 @@ source "https://supermarket.getchef.com"
 
 metadata
 
-cookbook 'chef-zero', github: 'stephenlauck/chef-zero', branch: 'fix_bin_path'
+cookbook 'chef-zero', github: 'sethvargo-cookbooks/chef-zero'
 
 cookbook 'pipeline_test', path: 'test/fixtures/cookbooks/pipeline_test'


### PR DESCRIPTION
Use updated chef-zero cookbook that set's the path to bin/chef-zero correctly.