### PR TITLE
Use an attribute to make the chef-client command call the same everywhere

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,3 +24,5 @@ default['java']['jdk_version'] = '7'
 default['pipeline']['chefdk']['version'] = 'latest'
 
 default['pipeline']['template']['cookbook'] = 'pipeline'
+
+default['pipeline']['chef_client_cmd'] = '/usr/bin/chef-client'

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -36,5 +36,5 @@ end
 sudo 'jenkins' do
   user      "jenkins"
   nopasswd  true
-  commands  ['/usr/bin/chef-client']
+  commands  [node['pipeline']['chef_client_cmd']]
 end

--- a/templates/default/_knife_commands.sh.erb
+++ b/templates/default/_knife_commands.sh.erb
@@ -12,4 +12,4 @@ berks upload --only=<%= node['pipeline']['berkshelf']['external']['group'] %>
 knife upload roles environments data_bags --chef-repo-path .
 
 # build jobs for all cookbooks in Berksfile except <%= node['pipeline']['berkshelf']['external']['group'] %> group
-sudo chef-client
+sudo <%= node['pipeline']['chef_client_cmd'] %>

--- a/test/fixtures/cookbooks/pipeline_test/templates/default/_knife_commands.sh.erb
+++ b/test/fixtures/cookbooks/pipeline_test/templates/default/_knife_commands.sh.erb
@@ -12,4 +12,4 @@ berks upload --only=<%= node['pipeline']['berkshelf']['external']['group'] %>
 knife upload roles environments data_bags --chef-repo-path .
 
 # build jobs for all cookbooks in Berksfile except <%= node['pipeline']['berkshelf']['external']['group'] %> group
-sudo chef-client -c /tmp/kitchen/client.rb -z -j /tmp/kitchen/dna.json
+sudo <%= node['pipeline']['chef_client_cmd'] %> -c /tmp/kitchen/client.rb -z -j /tmp/kitchen/dna.json


### PR DESCRIPTION
Solves this problem which I was seeing on my system:

```
+ knife upload roles environments data_bags --chef-repo-path .
+ sudo chef-client
sudo: no tty present and no askpass program specified
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```