### PR TITLE
Some general fixes

### DIFF
--- a/providers/job.rb
+++ b/providers/job.rb
@@ -7,8 +7,6 @@ action :create do
     source 'job-config.xml.erb'
       variables(
         :git_url => new_resource.git_url,
-        :branch => new_resource.branch,
-        :polling => new_resource.polling,
         :build_command => new_resource.build_command
       )
   end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,6 +30,8 @@ node['pipeline']['jenkins']['plugins'].each do |p|
   jenkins_plugin p do
     action :install
     notifies :execute, "jenkins_command[safe-restart]", :delayed
+    retries 5 
+    retry_delay 5
   end
 end
 


### PR DESCRIPTION
When installing plugins add retries in case of jenkins still restarting.

Remove unused template variables to fix FC034: Unused template variables.